### PR TITLE
Methods of extended classes are now properly ignored.

### DIFF
--- a/src/Rules/TypeHints/AbstractMissingTypeHintRule.php
+++ b/src/Rules/TypeHints/AbstractMissingTypeHintRule.php
@@ -313,6 +313,9 @@ abstract class AbstractMissingTypeHintRule implements Rule
 
         $parentClass = $class->getParentClass();
         if ($parentClass !== null) {
+            if ($parentClass->hasMethod($method->getName())) {
+                return true;
+            }
             return $this->isInherited($method, $parentClass);
         }
 

--- a/tests/Rules/TypeHints/MissingTypeHintRuleInMethodTest.php
+++ b/tests/Rules/TypeHints/MissingTypeHintRuleInMethodTest.php
@@ -21,6 +21,11 @@ class MissingTypeHintRuleInMethodTest extends \PHPStan\Rules\AbstractRuleTest
 				'In method "Foo::test", parameter $no_type_hint has no type-hint and no @param annotation.',
 				5,
 			],
-		]);
+            [
+                'In method "Baz::notInherited", parameter $no_type_hint has no type-hint and no @param annotation.',
+                36,
+            ],
+
+        ]);
 	}
 }

--- a/tests/Rules/TypeHints/data/StubClass.php
+++ b/tests/Rules/TypeHints/data/StubClass.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\TypeHints\data;
+
+class ParentStubClass
+{
+    public function bazbaz($no_type_hint) {
+
+    }
+}
+
+
+class StubClass extends ParentStubClass
+{
+    public function baz($no_type_hint) {
+
+    }
+}

--- a/tests/Rules/TypeHints/data/typehints_in_methods.php
+++ b/tests/Rules/TypeHints/data/typehints_in_methods.php
@@ -19,3 +19,22 @@ class Bar implements \TheCodingMachine\PHPStan\Rules\TypeHints\data\StubInterfac
     {
     }
 }
+
+class BazClass extends \TheCodingMachine\PHPStan\Rules\TypeHints\data\StubClass
+{
+    // Extended function
+    public function baz($no_type_hint)
+    {
+
+    }
+
+    public function bazbaz($no_type_hint)
+    {
+
+    }
+
+    public function notInherited($no_type_hint): void
+    {
+
+    }
+}


### PR DESCRIPTION
Previously, methods of extended classes were checked for type-hints. There is no point in doing that since the signature is dictated by the parent class.