### PR TITLE
object type hint is not available in PHP 7.1

### DIFF
--- a/src/Rules/TypeHints/AbstractMissingTypeHintRule.php
+++ b/src/Rules/TypeHints/AbstractMissingTypeHintRule.php
@@ -318,7 +318,8 @@ abstract class AbstractMissingTypeHintRule implements Rule
         // Manage interface/classes
         // Manage array of things => (cast to array)
 
-        if ($type instanceof Object_) {
+        // "object" type-hint is not available in PHP 7.1
+        if ($type instanceof Object_ && (string) $type !== 'object') {
             return ($isNullable?'?':'').((string)$type);
         }
 

--- a/tests/Rules/TypeHints/data/typehints.php
+++ b/tests/Rules/TypeHints/data/typehints.php
@@ -110,3 +110,11 @@ function test14(TheCodingMachine\PHPStan\Rules\TypeHints\data\StubIterator $type
 function test15(array $foo): array
 {
 }
+
+/**
+ * PHP 7.1 does not have object type hint so we should not ask for it.
+ * @param object $foo
+ */
+function test16($foo): void
+{
+}


### PR DESCRIPTION
Since object type-hint is not available in PHP 7.1, we should not enforce it (the extensions requires PHP 7.1+)