### PR TITLE
Switching to PHPStan parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpstan/phpstan": "^0.10",
-        "roave/better-reflection": "^3.0"
+        "phpstan/phpstan": "^0.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
     ignoreErrors:
-     - '#Call to an undefined method Roave\\BetterReflection\\Reflection\\ReflectionFunctionAbstract::getDeclaringClass().#'
+     - '#Access to an undefined property PhpParser\\Node\\FunctionLike::\$name.#'
 includes:
     - phpstan-strict-rules.neon

--- a/src/Rules/Exceptions/ThrowMustBundlePreviousExceptionRule.php
+++ b/src/Rules/Exceptions/ThrowMustBundlePreviousExceptionRule.php
@@ -63,7 +63,7 @@ class ThrowMustBundlePreviousExceptionRule implements Rule
             }
 
             /**
-             * @return array
+             * @return Node\Stmt\Throw_[]
              */
             public function getUnusedThrows(): array
             {

--- a/src/Rules/TypeHints/DebugContextInterface.php
+++ b/src/Rules/TypeHints/DebugContextInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\TypeHints;
+
+
+interface DebugContextInterface
+{
+    public function __toString();
+}

--- a/src/Rules/TypeHints/FunctionDebugContext.php
+++ b/src/Rules/TypeHints/FunctionDebugContext.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\TypeHints;
+
+
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Php\PhpParameterReflection;
+
+class FunctionDebugContext implements DebugContextInterface
+{
+    /**
+     * @var FunctionLike
+     */
+    private $function;
+    /**
+     * @var Scope
+     */
+    private $scope;
+
+    public function __construct(Scope $scope, FunctionLike $function)
+    {
+
+        $this->function = $function;
+        $this->scope = $scope;
+    }
+
+    public function __toString()
+    {
+        if ($this->function instanceof ClassMethod) {
+            if (!$this->scope->isInClass()) {
+                return 'Should not happen';
+            }
+
+            return sprintf('In method "%s::%s",', $this->scope->getClassReflection()->getDisplayName(), $this->function->name->name);
+        }
+        elseif ($this->function instanceof Function_) {
+            return sprintf('In function "%s",', $this->function->name->name);
+        }
+        return 'Should not happen';
+    }
+}

--- a/src/Rules/TypeHints/MissingTypeHintInFunctionRule.php
+++ b/src/Rules/TypeHints/MissingTypeHintInFunctionRule.php
@@ -3,6 +3,11 @@
 
 namespace TheCodingMachine\PHPStan\Rules\TypeHints;
 
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
+use PHPStan\Reflection\Php\PhpParameterReflection;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
@@ -16,19 +21,27 @@ class MissingTypeHintInFunctionRule extends AbstractMissingTypeHintRule
         return Node\Stmt\Function_::class;
     }
 
-    /**
-     * @param ReflectionFunctionAbstract|ReflectionParameter $reflection
-     * @return string
-     */
-    public function getContext($reflection): string
+    public function isReturnIgnored(Node $node): bool
     {
-        if ($reflection instanceof ReflectionParameter) {
-            $reflection = $reflection->getDeclaringFunction();
-        }
-        return 'In function "'.$reflection->getName().'"';
+        return false;
     }
 
-    public function isReturnIgnored(Node $node): bool
+    protected function getReflection(Node\FunctionLike $function, Scope $scope, Broker $broker) : ParametersAcceptorWithPhpDocs
+    {
+        $functionName = $function->name->name;
+        if (isset($function->namespacedName)) {
+            $functionName = (string) $function->namespacedName;
+        }
+        $functionNameName = new Node\Name($functionName);
+        if (!$broker->hasCustomFunction($functionNameName, null)) {
+            throw new \RuntimeException("Cannot find function '$functionName'");
+        }
+        $functionReflection = $broker->getCustomFunction($functionNameName, null);
+        /** @var \PHPStan\Reflection\ParametersAcceptorWithPhpDocs $parametersAcceptor */
+        return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+    }
+
+    protected function shouldSkip(Node\FunctionLike $function, Scope $scope): bool
     {
         return false;
     }

--- a/src/Rules/TypeHints/MissingTypeHintInFunctionRule.php
+++ b/src/Rules/TypeHints/MissingTypeHintInFunctionRule.php
@@ -5,6 +5,7 @@ namespace TheCodingMachine\PHPStan\Rules\TypeHints;
 
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Reflection\Php\PhpParameterReflection;
@@ -38,7 +39,8 @@ class MissingTypeHintInFunctionRule extends AbstractMissingTypeHintRule
         }
         $functionReflection = $broker->getCustomFunction($functionNameName, null);
         /** @var \PHPStan\Reflection\ParametersAcceptorWithPhpDocs $parametersAcceptor */
-        return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+        return $parametersAcceptor;
     }
 
     protected function shouldSkip(Node\FunctionLike $function, Scope $scope): bool

--- a/src/Rules/TypeHints/MissingTypeHintInMethodRule.php
+++ b/src/Rules/TypeHints/MissingTypeHintInMethodRule.php
@@ -60,7 +60,8 @@ class MissingTypeHintInMethodRule extends AbstractMissingTypeHintRule
             throw new \PHPStan\ShouldNotHappenException();
         }
         /** @var \PHPStan\Reflection\ParametersAcceptorWithPhpDocs $parametersAcceptor */
-        return ParametersAcceptorSelector::selectSingle($nativeMethod->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($nativeMethod->getVariants());
+        return $parametersAcceptor;
     }
 
     protected function shouldSkip(Node\FunctionLike $function, Scope $scope): bool

--- a/src/Rules/TypeHints/ParameterDebugContext.php
+++ b/src/Rules/TypeHints/ParameterDebugContext.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\TypeHints;
+
+
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Php\PhpParameterReflection;
+
+class ParameterDebugContext implements DebugContextInterface
+{
+    /**
+     * @var FunctionLike
+     */
+    private $function;
+    /**
+     * @var PhpParameterReflection
+     */
+    private $parameter;
+    /**
+     * @var Scope
+     */
+    private $scope;
+
+    public function __construct(Scope $scope, FunctionLike $function, PhpParameterReflection $parameter)
+    {
+
+        $this->function = $function;
+        $this->parameter = $parameter;
+        $this->scope = $scope;
+    }
+
+    public function __toString()
+    {
+        if ($this->function instanceof ClassMethod) {
+            if (!$this->scope->isInClass()) {
+                return 'Should not happen';
+            }
+
+            return sprintf('In method "%s::%s", parameter $%s', $this->scope->getClassReflection()->getDisplayName(), $this->function->name->name, $this->parameter->getName());
+        }
+        elseif ($this->function instanceof Function_) {
+            return sprintf('In function "%s", parameter $%s', $this->function->name->name, $this->parameter->getName());
+        }
+        return 'Should not happen';
+    }
+
+    public function getName(): string
+    {
+        return $this->parameter->getName();
+    }
+}

--- a/tests/Rules/TypeHints/MissingTypeHintRuleInFunctionTest.php
+++ b/tests/Rules/TypeHints/MissingTypeHintRuleInFunctionTest.php
@@ -59,7 +59,7 @@ class MissingTypeHintRuleInFunctionTest extends RuleTestCase
                 38,
             ],
             [
-                'In function "mismatch", parameter $param type is type-hinted to "string" but the @param annotation says it is a "int". Please fix the @param annotation.',
+                'In function "mismatch", parameter $param type is type-hinted to "string|null" but the @param annotation says it is a "int". Please fix the @param annotation.',
                 46,
             ],
             [
@@ -75,15 +75,19 @@ class MissingTypeHintRuleInFunctionTest extends RuleTestCase
                 62,
             ],
             [
-                'In function "test10", for parameter $id, invalid docblock @param encountered. Attempted to resolve "" but it appears to be empty',
+                'In function "test10", parameter $id has no type-hint and no @param annotation.',
                 76,
             ],
             [
-                'In function "test13", parameter $type_hintable type is type-hinted to "\ClassDoesNotExist" but the @param annotation says it is a "\DateTimeImmutable[]". Please fix the @param annotation.',
+                'In function "test13", parameter $type_hintable type is type-hinted to "ClassDoesNotExist" but the @param annotation says it is a "array<DateTimeImmutable>". Please fix the @param annotation.',
                 97,
             ],
             [
-                'In function "test15", for parameter $foo, invalid docblock @param encountered. "\array<string,string>" is not a valid Fqsen.',
+                'In function "test15", parameter $foo type is "array". Please provide a @param annotation to further specify the type of the array. For instance: @param int[] $foo',
+                110,
+            ],
+            [
+                'In function "test15", mismatching type-hints for return type. PHP type hint is "array" and docblock declared return type is a.',
                 110,
             ]
 

--- a/tests/Rules/TypeHints/data/typehints.php
+++ b/tests/Rules/TypeHints/data/typehints.php
@@ -104,8 +104,8 @@ function test14(TheCodingMachine\PHPStan\Rules\TypeHints\data\StubIterator $type
 
 /**
  * Test that unparseable params are not triggering exceptions.
- * @param array<string,string> $foo
- * @return array<string,string>
+ * @param a{r(ra)é $foo
+ * @return a{r(ra)é
  */
 function test15(array $foo): array
 {

--- a/tests/Rules/TypeHints/data/typehints.php
+++ b/tests/Rules/TypeHints/data/typehints.php
@@ -118,3 +118,17 @@ function test15(array $foo): array
 function test16($foo): void
 {
 }
+
+/**
+ * This should trigger no warning
+ */
+function test17(string $foo): void
+{
+}
+
+/**
+ * @return null|string
+ */
+function test18(): ?string
+{
+}


### PR DESCRIPTION
As suggested in #24 , PHPStan parser is now stable and complete enough so we can simply drop better-reflection.

This PR removes better-reflection and replaces it with PHPStan parser.
As a side effect, the rules should be really faster, which is awesome.

Ping @juliangut