### PR TITLE
Adding a new rule to forbid HTTP related superglobals usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This is a PHP 7.1+ rule:
 
 ### Superglobal related rules
 
-- The use of `$_GET`, `$_POST`, `$_FILES`, `$_COOKIE`, `$_SESSION`, `$_REQUEST` is forbidden. You should instead use 
-  your framework's request/session object.
+- The use of [`$_GET`, `$_POST`, `$_FILES`, `$_COOKIE`, `$_SESSION`, `$_REQUEST` is forbidden](http://bestpractices.thecodingmachine.com/php/organize_your_code.html#stop-using-superglobals-).
+  You should instead use your framework's request/session object.
 - Superglobal usage is still tolerated at the root scope (because it is typically used once in `index.php` to initialize
   PSR-7 request object)
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,18 @@ This is a PHP 7.1+ rule:
 
 [More about type-hinting related rules...](doc/typehinting_rules.md)
 
+### Superglobal related rules
+
+- The use of `$_GET`, `$_POST`, `$_FILES`, `$_COOKIE`, `$_SESSION`, `$_REQUEST` is forbidden. You should instead use 
+  your framework's request/session object.
+- Superglobal usage is still tolerated at the root scope (because it is typically used once in `index.php` to initialize
+  PSR-7 request object)
+
 ### Work-in-progress
 
-    // Don't use superglobals (__GET __POST)...
     // Always provide a "default" in a switch statement (and throw an exception if unexpected)
     // Never use public properties
+    // Never use globals
 
 ## Installation
 

--- a/phpstan-strict-rules.neon
+++ b/phpstan-strict-rules.neon
@@ -19,3 +19,7 @@ services:
     class: TheCodingMachine\PHPStan\Rules\TypeHints\MissingTypeHintInMethodRule
     tags:
       - phpstan.rules.rule
+  -
+    class: TheCodingMachine\PHPStan\Rules\Superglobals\NoSuperglobalsRule
+    tags:
+      - phpstan.rules.rule

--- a/src/Rules/Superglobals/NoSuperglobalsRule.php
+++ b/src/Rules/Superglobals/NoSuperglobalsRule.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\Superglobals;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * This rule checks that no superglobals are used in code.
+ */
+class NoSuperglobalsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\Variable::class;
+    }
+
+    /**
+     * @param Node\Expr\Variable $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $function = $scope->getFunction();
+        // If we are at the top level (not in a function), let's ignore all this.
+        // It might be ok.
+        if ($function === null) {
+            return [];
+        }
+
+        $forbiddenGlobals = [
+            '_GET', '_POST', '_FILES', '_COOKIE', '_SESSION', '_REQUEST'
+        ];
+
+        if (\in_array($node->name, $forbiddenGlobals, true)) {
+            $prefix = '';
+            if ($function instanceof MethodReflection) {
+                $prefix = 'In method "'.$function->getDeclaringClass()->getName().'::'.$function->getName().'", ';
+            } elseif ($function instanceof FunctionReflection) {
+                $prefix = 'In function "'.$function->getName().'", ';
+            }
+
+            return [$prefix.'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).'];
+        }
+
+        return [];
+    }
+}

--- a/tests/Rules/Exceptions/DoNotThrowExceptionBaseClassRuleTest.php
+++ b/tests/Rules/Exceptions/DoNotThrowExceptionBaseClassRuleTest.php
@@ -4,7 +4,6 @@ namespace PHPStan\Rules\Exceptions;
 
 use PHPStan\Testing\RuleTestCase;
 use TheCodingMachine\PHPStan\Rules\Exceptions\DoNotThrowExceptionBaseClassRule;
-use TheCodingMachine\PHPStan\Rules\Exceptions\EmptyExceptionRule;
 
 class DoNotThrowExceptionBaseClassRuleTest extends RuleTestCase
 {

--- a/tests/Rules/Superglobals/NoSuperglobalsRuleTest.php
+++ b/tests/Rules/Superglobals/NoSuperglobalsRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TheCodingMachine\PHPStan\Rules\Superglobals;
+
+use PHPStan\Testing\RuleTestCase;
+
+class NoSuperglobalsRuleTest extends RuleTestCase
+{
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new NoSuperglobalsRule();
+    }
+
+    public function testPost()
+    {
+        require_once __DIR__.'/data/superglobals.php';
+
+        $this->analyse([__DIR__ . '/data/superglobals.php'], [
+            [
+                'In function "foo", you should not use the $_POST superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).',
+                8,
+            ],
+            [
+                'In method "FooBarSuperGlobal::__construct", you should not use the $_GET superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).',
+                15,
+            ],
+        ]);
+    }
+}

--- a/tests/Rules/Superglobals/data/superglobals.php
+++ b/tests/Rules/Superglobals/data/superglobals.php
@@ -1,0 +1,17 @@
+<?php
+
+$foo = $_POST;
+
+function foo()
+{
+    echo $var;
+    echo $_POST['bar'];
+}
+
+class FooBarSuperGlobal
+{
+    public function __construct()
+    {
+        echo $_GET;
+    }
+}


### PR DESCRIPTION
This rule forbids HTTP related superglobals usage (_GET, _POST, _REQUEST, _COOKIES, _SESSION), except at the root scope of a file.

The rationale is that your framework should have a Request object to deal with it (PSR-7 FTW!)