### PR TITLE
New rule: switch statements must have a default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ This is a PHP 7.1+ rule:
 - Superglobal usage is still tolerated at the root scope (because it is typically used once in `index.php` to initialize
   PSR-7 request object)
 
+### Condition related rules
+
+- Switch statements should always check for unexpected values by [implementing a default case (and throwing an exception)](http://bestpractices.thecodingmachine.com/php/defensive_programming.html#always-check-for-unexpected-values)
+
 ### Work-in-progress
 
-    // Always provide a "default" in a switch statement (and throw an exception if unexpected)
     // Never use public properties
     // Never use globals
 

--- a/src/Rules/Conditionals/SwitchMustContainDefaultRule.php
+++ b/src/Rules/Conditionals/SwitchMustContainDefaultRule.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\Conditionals;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use TheCodingMachine\PHPStan\Utils\PrefixGenerator;
+
+/**
+ * A switch statement must always contain a "default" statement.
+ */
+class SwitchMustContainDefaultRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Switch_::class;
+    }
+
+    /**
+     * @param Switch_ $switch
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return string[]
+     */
+    public function processNode(Node $switch, Scope $scope): array
+    {
+        $errors = [];
+        $defaultFound = false;
+        foreach ($switch->cases as $case) {
+            if ($case->cond === null) {
+                $defaultFound = true;
+                break;
+            }
+        }
+
+        if (!$defaultFound) {
+            $errors[] = sprintf(PrefixGenerator::generatePrefix($scope).'switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception.');
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/Superglobals/NoSuperglobalsRule.php
+++ b/src/Rules/Superglobals/NoSuperglobalsRule.php
@@ -9,6 +9,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
+use TheCodingMachine\PHPStan\Utils\PrefixGenerator;
 
 /**
  * This rule checks that no superglobals are used in code.
@@ -39,14 +40,7 @@ class NoSuperglobalsRule implements Rule
         ];
 
         if (\in_array($node->name, $forbiddenGlobals, true)) {
-            $prefix = '';
-            if ($function instanceof MethodReflection) {
-                $prefix = 'In method "'.$function->getDeclaringClass()->getName().'::'.$function->getName().'", ';
-            } elseif ($function instanceof FunctionReflection) {
-                $prefix = 'In function "'.$function->getName().'", ';
-            }
-
-            return [$prefix.'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).'];
+            return [PrefixGenerator::generatePrefix($scope).'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).'];
         }
 
         return [];

--- a/src/Utils/PrefixGenerator.php
+++ b/src/Utils/PrefixGenerator.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Utils;
+
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+
+class PrefixGenerator
+{
+    public static function generatePrefix(Scope $scope): string
+    {
+        $function = $scope->getFunction();
+        $prefix = '';
+        if ($function instanceof MethodReflection) {
+            $prefix = 'In method "'.$function->getDeclaringClass()->getName().'::'.$function->getName().'", ';
+        } elseif ($function instanceof FunctionReflection) {
+            $prefix = 'In function "'.$function->getName().'", ';
+        }
+
+        return $prefix;
+    }
+}

--- a/tests/Rules/Conditionals/SwitchMustContainDefaultRuleTest.php
+++ b/tests/Rules/Conditionals/SwitchMustContainDefaultRuleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TheCodingMachine\PHPStan\Rules\Conditionals;
+
+use PHPStan\Testing\RuleTestCase;
+
+class SwitchMustContainDefaultRuleTest extends RuleTestCase
+{
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new SwitchMustContainDefaultRule();
+    }
+
+    public function testProcessNode()
+    {
+        $this->analyse([__DIR__ . '/data/switch.php'], [
+            [
+                'In function "baz", switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception.',
+                11,
+            ],
+        ]);
+    }
+}

--- a/tests/Rules/Conditionals/data/switch.php
+++ b/tests/Rules/Conditionals/data/switch.php
@@ -1,0 +1,15 @@
+<?php
+
+function baz() {
+    switch ($foo) {
+        case "bar":
+            break;
+        default:
+            break;
+    }
+
+    switch ($foo) {
+        case "bar":
+            break;
+    }
+}


### PR DESCRIPTION
We should always check for unexpected values.

Therefore, a switch statement should always have a default case. If the code is supposed to go through on of the cases, the default statement must throw an exception.

See http://bestpractices.thecodingmachine.com/php/defensive_programming.html#always-check-for-unexpected-values