### PR TITLE
Base exceptions must be rethrown if caught.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ They are more "strict" than the default PHPStan rules and some may be controvers
 - You should not throw the "Exception" base class directly [but throw a sub-class instead](http://bestpractices.thecodingmachine.com/php/error_handling.html#subtyping-exceptions).
 - You should not have empty catch statements
 - When throwing an exception inside a catch block, [you should pass the catched exception as the "previous" exception](http://bestpractices.thecodingmachine.com/php/error_handling.html#wrapping-an-exception-do-not-lose-the-previous-exception)
+- If you catch a `Throwable`, an `Exception` or a `RuntimeException`, you must rethrow the exception.
 
 ### Type-hinting related rules
 

--- a/phpstan-strict-rules.neon
+++ b/phpstan-strict-rules.neon
@@ -12,6 +12,10 @@ services:
     tags:
       - phpstan.rules.rule
   -
+    class: TheCodingMachine\PHPStan\Rules\Exceptions\MustRethrowRule
+    tags:
+      - phpstan.rules.rule
+  -
     class: TheCodingMachine\PHPStan\Rules\TypeHints\MissingTypeHintInFunctionRule
     tags:
       - phpstan.rules.rule

--- a/src/Rules/Exceptions/MustRethrowRule.php
+++ b/src/Rules/Exceptions/MustRethrowRule.php
@@ -35,15 +35,15 @@ class MustRethrowRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // Let's only apply the filter to \Exception, \RuntimeException or \Throwable
-        $elected = false;
+        $exceptionType = null;
         foreach ($node->types as $type) {
             if (in_array((string)$type, [Exception::class, RuntimeException::class, Throwable::class], true)) {
-                $elected = true;
+                $exceptionType = (string)$type;
                 break;
             }
         }
 
-        if (!$elected) {
+        if ($exceptionType === null) {
             return [];
         }
 
@@ -76,7 +76,7 @@ class MustRethrowRule implements Rule
         $errors = [];
 
         if (!$visitor->isThrowFound()) {
-            $errors[] = sprintf('%scaught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.', PrefixGenerator::generatePrefix($scope));
+            $errors[] = sprintf('%scaught "%s" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.', PrefixGenerator::generatePrefix($scope), $exceptionType);
         }
 
         return $errors;

--- a/src/Rules/Exceptions/MustRethrowRule.php
+++ b/src/Rules/Exceptions/MustRethrowRule.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Rules\Rule;
 use RuntimeException;
+use TheCodingMachine\PHPStan\Utils\PrefixGenerator;
 use Throwable;
 
 /**
@@ -75,7 +76,7 @@ class MustRethrowRule implements Rule
         $errors = [];
 
         if (!$visitor->isThrowFound()) {
-            $errors[] = sprintf('Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.');
+            $errors[] = sprintf('%scaught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.', PrefixGenerator::generatePrefix($scope));
         }
 
         return $errors;

--- a/src/Rules/Exceptions/MustRethrowRule.php
+++ b/src/Rules/Exceptions/MustRethrowRule.php
@@ -1,0 +1,83 @@
+<?php
+
+
+namespace TheCodingMachine\PHPStan\Rules\Exceptions;
+
+use Exception;
+use function in_array;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Rules\Rule;
+use RuntimeException;
+use Throwable;
+
+/**
+ * When catching \Exception, \RuntimeException or \Throwable, the exception MUST be thrown again
+ * (unless you are developing an exception handler...)
+ */
+class MustRethrowRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Catch_::class;
+    }
+
+    /**
+     * @param Catch_ $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Let's only apply the filter to \Exception, \RuntimeException or \Throwable
+        $elected = false;
+        foreach ($node->types as $type) {
+            if (in_array((string)$type, [Exception::class, RuntimeException::class, Throwable::class], true)) {
+                $elected = true;
+                break;
+            }
+        }
+
+        if (!$elected) {
+            return [];
+        }
+
+        // Let's visit and find a throw.
+        $visitor = new class() extends NodeVisitorAbstract {
+            private $throwFound = false;
+
+            public function leaveNode(Node $node)
+            {
+                if ($node instanceof Node\Stmt\Throw_) {
+                    $this->throwFound = true;
+                }
+            }
+
+            /**
+             * @return bool
+             */
+            public function isThrowFound(): bool
+            {
+                return $this->throwFound;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+
+        $traverser->addVisitor($visitor);
+
+        $traverser->traverse($node->stmts);
+
+        $errors = [];
+
+        if (!$visitor->isThrowFound()) {
+            $errors[] = sprintf('Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.');
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Rules/Exceptions/MustRethrowRuleTest.php
+++ b/tests/Rules/Exceptions/MustRethrowRuleTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Exceptions;
+
+use PHPStan\Testing\RuleTestCase;
+use TheCodingMachine\PHPStan\Rules\Exceptions\MustRethrowRule;
+use TheCodingMachine\PHPStan\Rules\Exceptions\ThrowMustBundlePreviousExceptionRule;
+
+class MustRethrowRuleTest extends RuleTestCase
+{
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new MustRethrowRule();
+    }
+
+    public function testCheckCatchedException()
+    {
+        $this->analyse([__DIR__ . '/data/must_rethrow.php'], [
+            [
+                'Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                18,
+            ],
+            [
+                'Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                24,
+            ],
+            [
+                'Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                30,
+            ],
+        ]);
+    }
+}

--- a/tests/Rules/Exceptions/MustRethrowRuleTest.php
+++ b/tests/Rules/Exceptions/MustRethrowRuleTest.php
@@ -17,16 +17,16 @@ class MustRethrowRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/must_rethrow.php'], [
             [
-                'Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                'caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
                 18,
             ],
             [
-                'Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                'caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
                 24,
             ],
             [
-                'Caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
-                30,
+                'In function "TestCatch\foo", caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                31,
             ],
         ]);
     }

--- a/tests/Rules/Exceptions/MustRethrowRuleTest.php
+++ b/tests/Rules/Exceptions/MustRethrowRuleTest.php
@@ -17,15 +17,15 @@ class MustRethrowRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/must_rethrow.php'], [
             [
-                'caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                'caught "Exception" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.',
                 18,
             ],
             [
-                'caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                'caught "Throwable" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.',
                 24,
             ],
             [
-                'In function "TestCatch\foo", caught \Exception, \Throwable or \RuntimeException must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" to propagate the exception.',
+                'In function "TestCatch\foo", caught "RuntimeException" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.',
                 31,
             ],
         ]);

--- a/tests/Rules/Exceptions/data/must_rethrow.php
+++ b/tests/Rules/Exceptions/data/must_rethrow.php
@@ -26,10 +26,12 @@ try {
     $foo = 42;
 }
 
-try {
-} catch (\RuntimeException $e) {
-    // Do something
-    $foo = 42;
+function foo() {
+    try {
+    } catch (\RuntimeException $e) {
+        // Do something
+        $foo = 42;
+    }
 }
 
 try {

--- a/tests/Rules/Exceptions/data/must_rethrow.php
+++ b/tests/Rules/Exceptions/data/must_rethrow.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TestCatch;
+
+class FooCatch
+{
+}
+
+class MyCatchException extends \Exception
+{
+}
+
+try {
+} catch (\TestCatch\MyCatchException $e) {
+}
+
+try {
+} catch (\Exception $e) {
+    // Do something
+    $foo = 42;
+}
+
+try {
+} catch (\Throwable $e) {
+    // Do something
+    $foo = 42;
+}
+
+try {
+} catch (\RuntimeException $e) {
+    // Do something
+    $foo = 42;
+}
+
+try {
+} catch (\Exception $e) {
+    // Do something
+    throw $e;
+}


### PR DESCRIPTION
New rule: When catching Exception, Throwable or RuntimeException, we should ensure that the exception is always rethrown (or wrapped into another exception that is thrown).

Closes #33 