### PR TITLE
Adding bitly links for most rules pointing to TCM best practices

### DIFF
--- a/src/Rules/Conditionals/SwitchMustContainDefaultRule.php
+++ b/src/Rules/Conditionals/SwitchMustContainDefaultRule.php
@@ -38,7 +38,7 @@ class SwitchMustContainDefaultRule implements Rule
         }
 
         if (!$defaultFound) {
-            $errors[] = sprintf(PrefixGenerator::generatePrefix($scope).'switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception.');
+            $errors[] = sprintf(PrefixGenerator::generatePrefix($scope).'switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception. More info: http://bit.ly/switchdefault');
         }
 
         return $errors;

--- a/src/Rules/Exceptions/DoNotThrowExceptionBaseClassRule.php
+++ b/src/Rules/Exceptions/DoNotThrowExceptionBaseClassRule.php
@@ -38,7 +38,7 @@ class DoNotThrowExceptionBaseClassRule implements Rule
 
             if ($class === 'Exception') {
                 return [
-                    'Do not throw the \Exception base class. Instead, extend the \Exception base class'
+                    'Do not throw the \Exception base class. Instead, extend the \Exception base class. More info: http://bit.ly/subtypeexception'
                 ];
             }
         }

--- a/src/Rules/Exceptions/MustRethrowRule.php
+++ b/src/Rules/Exceptions/MustRethrowRule.php
@@ -76,7 +76,7 @@ class MustRethrowRule implements Rule
         $errors = [];
 
         if (!$visitor->isThrowFound()) {
-            $errors[] = sprintf('%scaught "%s" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.', PrefixGenerator::generatePrefix($scope), $exceptionType);
+            $errors[] = sprintf('%scaught "%s" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception. More info: http://bit.ly/failloud', PrefixGenerator::generatePrefix($scope), $exceptionType);
         }
 
         return $errors;

--- a/src/Rules/Exceptions/ThrowMustBundlePreviousExceptionRule.php
+++ b/src/Rules/Exceptions/ThrowMustBundlePreviousExceptionRule.php
@@ -80,7 +80,7 @@ class ThrowMustBundlePreviousExceptionRule implements Rule
         $errors = [];
 
         foreach ($visitor->getUnusedThrows() as $throw) {
-            $errors[] = sprintf('Thrown exceptions in a catch block must bundle the previous exception (see throw statement line %d)', $throw->getLine());
+            $errors[] = sprintf('Thrown exceptions in a catch block must bundle the previous exception (see throw statement line %d). More info: http://bit.ly/bundleexception', $throw->getLine());
         }
 
         return $errors;

--- a/src/Rules/Superglobals/NoSuperglobalsRule.php
+++ b/src/Rules/Superglobals/NoSuperglobalsRule.php
@@ -40,7 +40,7 @@ class NoSuperglobalsRule implements Rule
         ];
 
         if (\in_array($node->name, $forbiddenGlobals, true)) {
-            return [PrefixGenerator::generatePrefix($scope).'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).'];
+            return [PrefixGenerator::generatePrefix($scope).'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request). More info: http://bit.ly/nosuperglobals'];
         }
 
         return [];

--- a/tests/Rules/Conditionals/SwitchMustContainDefaultRuleTest.php
+++ b/tests/Rules/Conditionals/SwitchMustContainDefaultRuleTest.php
@@ -15,7 +15,7 @@ class SwitchMustContainDefaultRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/switch.php'], [
             [
-                'In function "baz", switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception.',
+                'In function "baz", switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception. More info: http://bit.ly/switchdefault',
                 11,
             ],
         ]);

--- a/tests/Rules/Exceptions/DoNotThrowExceptionBaseClassRuleTest.php
+++ b/tests/Rules/Exceptions/DoNotThrowExceptionBaseClassRuleTest.php
@@ -16,7 +16,7 @@ class DoNotThrowExceptionBaseClassRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/throw_exception.php'], [
             [
-                'Do not throw the \Exception base class. Instead, extend the \Exception base class',
+                'Do not throw the \Exception base class. Instead, extend the \Exception base class. More info: http://bit.ly/subtypeexception',
                 16,
             ],
         ]);

--- a/tests/Rules/Exceptions/MustRethrowRuleTest.php
+++ b/tests/Rules/Exceptions/MustRethrowRuleTest.php
@@ -17,15 +17,15 @@ class MustRethrowRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/must_rethrow.php'], [
             [
-                'caught "Exception" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.',
+                'caught "Exception" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception. More info: http://bit.ly/failloud',
                 18,
             ],
             [
-                'caught "Throwable" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.',
+                'caught "Throwable" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception. More info: http://bit.ly/failloud',
                 24,
             ],
             [
-                'In function "TestCatch\foo", caught "RuntimeException" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception.',
+                'In function "TestCatch\foo", caught "RuntimeException" must be rethrown. Either catch a more specific exception or add a "throw" clause in the "catch" block to propagate the exception. More info: http://bit.ly/failloud',
                 31,
             ],
         ]);

--- a/tests/Rules/Exceptions/ThrowMustBundlePreviousExceptionRuleTest.php
+++ b/tests/Rules/Exceptions/ThrowMustBundlePreviousExceptionRuleTest.php
@@ -16,7 +16,7 @@ class ThrowMustBundlePreviousExceptionRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/throw_must_bundle_previous_exception.php'], [
             [
-                'Thrown exceptions in a catch block must bundle the previous exception (see throw statement line 28)',
+                'Thrown exceptions in a catch block must bundle the previous exception (see throw statement line 28). More info: http://bit.ly/bundleexception',
                 26,
             ],
         ]);

--- a/tests/Rules/Superglobals/NoSuperglobalsRuleTest.php
+++ b/tests/Rules/Superglobals/NoSuperglobalsRuleTest.php
@@ -17,11 +17,11 @@ class NoSuperglobalsRuleTest extends RuleTestCase
 
         $this->analyse([__DIR__ . '/data/superglobals.php'], [
             [
-                'In function "foo", you should not use the $_POST superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).',
+                'In function "foo", you should not use the $_POST superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request). More info: http://bit.ly/nosuperglobals',
                 8,
             ],
             [
-                'In method "FooBarSuperGlobal::__construct", you should not use the $_GET superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request).',
+                'In method "FooBarSuperGlobal::__construct", you should not use the $_GET superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request). More info: http://bit.ly/nosuperglobals',
                 15,
             ],
         ]);


### PR DESCRIPTION
Note: One notable rule is missing in TCM best practices: type-hint everything!