### PR TITLE
Non native void return types

### DIFF
--- a/src/Rules/TypeHints/AbstractMissingTypeHintRule.php
+++ b/src/Rules/TypeHints/AbstractMissingTypeHintRule.php
@@ -25,6 +25,7 @@ use PHPStan\Reflection\Php\PhpParameterReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPStan\Type\VoidType;
 
 abstract class AbstractMissingTypeHintRule implements Rule
 {
@@ -323,6 +324,7 @@ abstract class AbstractMissingTypeHintRule implements Rule
             || $type instanceof FloatType
             || $type instanceof CallableType
             || $type instanceof IterableType
+            || $type instanceof VoidType
         ) {
             return true;
         }

--- a/tests/Rules/TypeHints/MissingTypeHintRuleInFunctionTest.php
+++ b/tests/Rules/TypeHints/MissingTypeHintRuleInFunctionTest.php
@@ -89,6 +89,10 @@ class MissingTypeHintRuleInFunctionTest extends RuleTestCase
             [
                 'In function "test15", mismatching type-hints for return type. PHP type hint is "array" and docblock declared return type is a.',
                 110,
+            ],
+            [
+                'In function "test19", a "void" return type can be added. More info: http://bit.ly/usetypehint',
+                139,
             ]
 
         ]);

--- a/tests/Rules/TypeHints/data/typehints.php
+++ b/tests/Rules/TypeHints/data/typehints.php
@@ -132,3 +132,10 @@ function test17(string $foo): void
 function test18(): ?string
 {
 }
+
+/**
+ * @return void
+ */
+function test19()
+{
+}


### PR DESCRIPTION
Void return types type-hinted in the PHPDoc but not in native typehint do not throw errors
