### PR TITLE
Adding a @ignoreException annotation to override empty catch block rule

### DIFF
--- a/src/Rules/Exceptions/EmptyExceptionRule.php
+++ b/src/Rules/Exceptions/EmptyExceptionRule.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt\Catch_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Rules\Rule;
+use function strpos;
 
 class EmptyExceptionRule implements Rule
 {
@@ -25,7 +26,7 @@ class EmptyExceptionRule implements Rule
     {
         if ($this->isEmpty($node->stmts)) {
             return [
-                'Empty catch block'
+                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.'
             ];
         }
 
@@ -41,6 +42,12 @@ class EmptyExceptionRule implements Rule
         foreach ($stmts as $stmt) {
             if (!$stmt instanceof Node\Stmt\Nop) {
                 return false;
+            } else {
+                foreach ($stmt->getComments() as $comment) {
+                    if (strpos($comment->getText(), '@ignoreException') !== false) {
+                        return false;
+                    }
+                }
             }
         }
 

--- a/tests/Rules/Exceptions/EmptyExceptionRuleTest.php
+++ b/tests/Rules/Exceptions/EmptyExceptionRuleTest.php
@@ -16,11 +16,11 @@ class EmptyExceptionRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/catch.php'], [
             [
-                'Empty catch block',
+                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.',
                 14,
             ],
             [
-                'Empty catch block',
+                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.',
                 24,
             ],
         ]);

--- a/tests/Rules/Exceptions/data/catch.php
+++ b/tests/Rules/Exceptions/data/catch.php
@@ -24,3 +24,8 @@ try {
 } catch (\Exception $e) {
     // Do nothing
 }
+
+try {
+} catch (\Exception $e) {
+    // @ignoreException
+}


### PR DESCRIPTION
This PR allows to authorize an empty catch block by adding an annotation in a comment:

```php
try {
    // ...
} catch (\Exception $e) {
    // @ignoreException
}
```

This closes #43 