### PR TITLE
Supplementing the rule

### DIFF
--- a/src/Rules/Exceptions/ThrowMustBundlePreviousExceptionRule.php
+++ b/src/Rules/Exceptions/ThrowMustBundlePreviousExceptionRule.php
@@ -56,6 +56,9 @@ class ThrowMustBundlePreviousExceptionRule implements Rule
                     if ($node->name === $this->catchedVariableName) {
                         $this->exceptionUsedCount++;
                     }
+                    if ($node->getAttribute('parent') instanceof Node\Expr\New_) {
+                        $this->exceptionUsedCount--;
+                    }
                     return null;
                 }
 

--- a/tests/Rules/Exceptions/ThrowMustBundlePreviousExceptionRuleTest.php
+++ b/tests/Rules/Exceptions/ThrowMustBundlePreviousExceptionRuleTest.php
@@ -19,6 +19,10 @@ class ThrowMustBundlePreviousExceptionRuleTest extends RuleTestCase
                 'Thrown exceptions in a catch block must bundle the previous exception (see throw statement line 28). More info: http://bit.ly/bundleexception',
                 26,
             ],
+            [
+                'Thrown exceptions in a catch block must bundle the previous exception (see throw statement line 40). More info: http://bit.ly/bundleexception',
+                38,
+            ],
         ]);
     }
 }

--- a/tests/Rules/Exceptions/data/throw_must_bundle_previous_exception.php
+++ b/tests/Rules/Exceptions/data/throw_must_bundle_previous_exception.php
@@ -33,3 +33,9 @@ try {
     // This is okay
     throw new \Exception();
 }
+
+try {
+} catch (\Exception $e) {
+    // This is not okay
+    throw new $e;
+}


### PR DESCRIPTION
While checking many MRs, I notice typos. I want to fix them

```
        try {
        } catch (Throwable $e) {
            throw new $e(); // fail
        }
```
