### PR TITLE
update rules for phpstan 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 /vendor/*
 .*~
+/.phpunit.result.cache
 /composer.lock
 /phpunit.xml
 /tmp

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
-        "phpstan/phpstan": "^1.0"
+        "php": "^7.4|^8.0",
+        "phpstan/phpstan": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1",
+        "phpunit/phpunit": "^9.5",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,5 @@
-<phpunit
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	bootstrap="tests/bootstrap.php"
 	colors="true"
 	backupGlobals="false"
@@ -12,25 +13,20 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
->
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+	<coverage>
+		<include>
+			<directory suffix=".php">./src</directory>
+		</include>
+		<report>
+			<clover outputFile="build/logs/clover.xml"/>
+			<html outputDirectory="build/coverage"/>
+			<text outputFile="php://stdout" showUncoveredFiles="true" showOnlySummary="true"/>
+		</report>
+	</coverage>
 	<testsuites>
 		<testsuite name="Test suite">
 			<directory>./tests/</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist>
-			<directory suffix=".php">./src</directory>
-		</whitelist>
-	</filter>
-	<logging>
-		<log
-			type="coverage-text"
-			target="php://stdout"
-			showUncoveredFiles="true"
-			showOnlySummary="true"
-		/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-	</logging>
 </phpunit>

--- a/src/Rules/Conditionals/SwitchMustContainDefaultRule.php
+++ b/src/Rules/Conditionals/SwitchMustContainDefaultRule.php
@@ -5,10 +5,10 @@ namespace TheCodingMachine\PHPStan\Rules\Conditionals;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Switch_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
 use TheCodingMachine\PHPStan\Utils\PrefixGenerator;
 
 /**
@@ -24,15 +24,15 @@ class SwitchMustContainDefaultRule implements Rule
     }
 
     /**
-     * @param Switch_ $switch
+     * @param Switch_ $node
      * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
+     * @return RuleError[]
      */
-    public function processNode(Node $switch, Scope $scope): array
+    public function processNode(Node $node, Scope $scope): array
     {
         $errors = [];
         $defaultFound = false;
-        foreach ($switch->cases as $case) {
+        foreach ($node->cases as $case) {
             if ($case->cond === null) {
                 $defaultFound = true;
                 break;
@@ -40,7 +40,11 @@ class SwitchMustContainDefaultRule implements Rule
         }
 
         if (!$defaultFound) {
-            $errors[] = sprintf(PrefixGenerator::generatePrefix($scope).'switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception. More info: http://bit.ly/switchdefault');
+            $errors[] = RuleErrorBuilder::message(sprintf(PrefixGenerator::generatePrefix($scope).'switch statement does not have a "default" case.'))
+                ->file($scope->getFile())
+                ->line($node->getStartLine())
+                ->tip('If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception. More info: http://bit.ly/switchdefault')
+                ->build();
         }
 
         return $errors;

--- a/src/Rules/Exceptions/EmptyExceptionRule.php
+++ b/src/Rules/Exceptions/EmptyExceptionRule.php
@@ -6,8 +6,9 @@ namespace TheCodingMachine\PHPStan\Rules\Exceptions;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Catch_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Broker\Broker;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
 use function strpos;
 
 /**
@@ -23,13 +24,17 @@ class EmptyExceptionRule implements Rule
     /**
      * @param \PhpParser\Node\Stmt\Catch_ $node
      * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
+     * @return RuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
         if ($this->isEmpty($node->stmts)) {
             return [
-                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.'
+                RuleErrorBuilder::message('Empty catch block.')
+                    ->tip('If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.')
+                    ->file($scope->getFile())
+                    ->line($node->getStartLine())
+                    ->build(),
             ];
         }
 

--- a/src/Rules/Superglobals/NoSuperglobalsRule.php
+++ b/src/Rules/Superglobals/NoSuperglobalsRule.php
@@ -5,10 +5,9 @@ namespace TheCodingMachine\PHPStan\Rules\Superglobals;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
-use PHPStan\ShouldNotHappenException;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
 use TheCodingMachine\PHPStan\Utils\PrefixGenerator;
 
 /**
@@ -26,7 +25,7 @@ class NoSuperglobalsRule implements Rule
     /**
      * @param Node\Expr\Variable $node
      * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
+     * @return RuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -42,7 +41,13 @@ class NoSuperglobalsRule implements Rule
         ];
 
         if (\in_array($node->name, $forbiddenGlobals, true)) {
-            return [PrefixGenerator::generatePrefix($scope).'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request). More info: http://bit.ly/nosuperglobals'];
+            $message = PrefixGenerator::generatePrefix($scope).'you should not use the $'.$node->name.' superglobal. You should instead rely on your framework that provides you with a "request" object (for instance a PSR-7 RequestInterface or a Symfony Request). More info: http://bit.ly/nosuperglobals';
+            return [
+                RuleErrorBuilder::message($message)
+                    ->line($node->getStartLine())
+                    ->file($scope->getFile())
+                    ->build(),
+            ];
         }
 
         return [];

--- a/tests/Rules/Conditionals/SwitchMustContainDefaultRuleTest.php
+++ b/tests/Rules/Conditionals/SwitchMustContainDefaultRuleTest.php
@@ -15,7 +15,8 @@ class SwitchMustContainDefaultRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/switch.php'], [
             [
-                'In function "baz", switch statement does not have a "default" case. If your code is supposed to enter at least one "case" or another, consider adding a "default" case that throws an exception. More info: http://bit.ly/switchdefault',
+                "In function \"baz\", switch statement does not have a \"default\" case.\n" .
+                "    💡 If your code is supposed to enter at least one \"case\" or another, consider adding a \"default\" case that throws an exception. More info: http://bit.ly/switchdefault",
                 11,
             ],
         ]);

--- a/tests/Rules/Exceptions/DoNotThrowExceptionBaseClassRuleTest.php
+++ b/tests/Rules/Exceptions/DoNotThrowExceptionBaseClassRuleTest.php
@@ -16,7 +16,7 @@ class DoNotThrowExceptionBaseClassRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/throw_exception.php'], [
             [
-                'Do not throw the \Exception base class. Instead, extend the \Exception base class. More info: http://bit.ly/subtypeexception',
+                "Do not throw the \\Exception base class.\n    💡 Instead, extend the \\Exception base class. More info: http://bit.ly/subtypeexception",
                 16,
             ],
         ]);

--- a/tests/Rules/Exceptions/EmptyExceptionRuleTest.php
+++ b/tests/Rules/Exceptions/EmptyExceptionRuleTest.php
@@ -16,11 +16,11 @@ class EmptyExceptionRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/catch.php'], [
             [
-                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.',
+                "Empty catch block.\n    💡 If you are sure this is meant to be empty, please add a \"// @ignoreException\" comment in the catch block.",
                 14,
             ],
             [
-                'Empty catch block. If you are sure this is meant to be empty, please add a "// @ignoreException" comment in the catch block.',
+                "Empty catch block.\n    💡 If you are sure this is meant to be empty, please add a \"// @ignoreException\" comment in the catch block.",
                 24,
             ],
         ]);

--- a/tests/Rules/Exceptions/data/throw_exception.php
+++ b/tests/Rules/Exceptions/data/throw_exception.php
@@ -19,7 +19,8 @@ function bar()
 function baz()
 {
     try {
-        //...
+        // We need to do something or phpstan will skip the evaluation of the catch block
+        bar();
     } catch (\Exception $e) {
         // This is ok
         throw $e;


### PR DESCRIPTION
I've updated the rules to be compatible with phpstan 2, dropping the support for phpstan 1.

Rules now returns an array of objects (instance of `RuleError`) instead of strings.
Hints are now added to `RuleError` object using `RuleErrorBuilder::tip` method.

Fix #66 